### PR TITLE
Use `mapThemeProps` from `ca-ui-themer` for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "ca-ui-react-themer": "^2.0.0",
     "object-assign": "^4.1.0",
+    "object.omit": "^2.0.1",
     "react-jss": "^5.1.1",
     "recompose": ">=0.5.0"
   },

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -10,7 +10,7 @@
 import injectSheet from 'react-jss';
 import compose from 'recompose/compose';
 
-import { mapperDecorator } from '../utils';
+import { mapPropsDecorator } from '../utils';
 
 /**
  * Creates a new JSS middleware for themer.
@@ -24,6 +24,6 @@ export function createMiddleware(customInjectSheet: ?Function) {
   return (component: any, resolvedTheme: any = {}) =>
     compose(
       injectSheetInstance(resolvedTheme.styles),
-      mapperDecorator
+      mapPropsDecorator,
     )(component);
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,10 +5,11 @@
  */
 
 // @flow
-/* eslint-disable import/prefer-default-export */
 
 import mapProps from 'recompose/mapProps';
 import objectAssign from 'object-assign';
+import objectOmit from 'object.omit';
+import { mapThemeProps } from 'ca-ui-themer';
 
 /**
  * Property mapper to trasform ReactJSS output props into themer props.
@@ -17,13 +18,17 @@ import objectAssign from 'object-assign';
  * @return {Object}       Output props to be passed to themed component
  */
 export const mapper = (props: Object) => {
-  const styles = props.sheet && props.sheet.classes ? props.sheet.classes : {};
-  const theme = objectAssign({}, props.theme, { styles });
-  const newProps = objectAssign({}, props, { theme });
-  delete newProps.sheet;
-  delete newProps.classes;
-  return newProps;
+  let styles;
+  if (props.sheet && props.sheet.classes) {
+    styles = props.sheet.classes;
+  } else if (props.classes) {
+    styles = props.classes;
+  } else {
+    return props;
+  }
+  const resolvedTheme = objectAssign({}, props.theme, { styles });
+  return mapThemeProps(objectOmit(props, ['sheet', 'classes']), resolvedTheme);
 };
 
 // react decorator based on prop-mapper function
-export const mapperDecorator = mapProps(mapper);
+export const mapPropsDecorator = mapProps(mapper);

--- a/tests/utils/index.spec.js
+++ b/tests/utils/index.spec.js
@@ -6,8 +6,6 @@
 
 // @flow
 
-import isEqual from 'lodash/isEqual';
-
 import { mapper } from '../../src/utils';
 
 const testPropsInput = {
@@ -25,20 +23,27 @@ const testPropsInput = {
   },
 };
 
+const testPropsInputClasses = {
+  test: 'testProp',
+  classes: {
+    root: 'root-class-1234',
+  },
+};
+
 describe('mapper', () => {
   test('maps props.sheet.classes property to props.theme.styles', () => {
     const testPropsOutput = mapper(testPropsInput);
     expect(testPropsOutput.theme.styles.root).toBe('root-class-1234');
   });
 
-  test('returns empty object in props.theme.styles if no sheet prop is found in input props', () => {
-    const testPropsOutput = mapper({});
-    expect(isEqual(testPropsOutput, { theme: { styles: {} } })).toBe(true);
+  test('maps props.classes property to props.theme.styles', () => {
+    const testPropsOutput = mapper(testPropsInputClasses);
+    expect(testPropsOutput.theme.styles.root).toBe('root-class-1234');
   });
 
-  test('returns empty object in props.theme.styles if sheet.classes is undefined in input props', () => {
-    const testPropsOutput = mapper({ sheet: { test: 'test' } });
-    expect(isEqual(testPropsOutput, { theme: { styles: {} } })).toBe(true);
+  test('returns empty object in props.theme.styles if no sheet prop is found in input props', () => {
+    const testPropsOutput = mapper({ test: 'test' });
+    expect(testPropsOutput).toEqual({ test: 'test' });
   });
 
   test('keeps existing props', () => {


### PR DESCRIPTION
## Status
**READY**

## Description
Use `mapThemeProps` from `ca-ui-themer` for consistency. The `ca-ui-themer` should be the only library that sets the props to be passed to the themed component. This way, any updates regarding theme props can be isolated to `ca-ui-themer`.

## Impacted Areas in Application

* `utils.mapper`
