### PR TITLE
feat: bump dependencies

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,8 +13,9 @@
     "ca-ui-react-themer": "^1.0.0",
     "ca-ui-react-themer-jss": "^1.0.0",
     "ca-ui-themer": "^1.0.0",
-    "jss": "^5.5.6",
-    "jss-preset-default": "^0.9.0",
+    "jss": "^8.0.0",
+    "jss-isolate": "^4.0.1",
+    "jss-preset-default": "^3.0.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-jss": "^4.2.0"

--- a/example/src/themer.js
+++ b/example/src/themer.js
@@ -7,16 +7,11 @@
 import { create as createJss } from 'jss';
 import { create as createInjectSheet } from 'react-jss';
 import preset from 'jss-preset-default';
-import isolate from 'jss-isolate';
 import { create as createThemer } from 'ca-ui-themer';
 import { create as createReactThemer } from 'ca-ui-react-themer';
 import { createMiddleware as createReactThemerJssMiddleware } from 'ca-ui-react-themer-jss';
 
 const jss = createJss(preset());
-jss.use(isolate({
-  isolate: true,
-}));
-
 const injectSheet = createInjectSheet(jss);
 const reactThemerJssMiddleware = createReactThemerJssMiddleware(injectSheet);
 const themer = createThemer();

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ca-ui-react-themer": "^2.3.0",
     "ca-ui-themer": "^2.3.0",
     "jss": "^8.0.1",
+    "jss-isolate": "^4.0.1",
     "jss-preset-default": "^3.0.0",
     "object-assign": "^4.1.1",
     "object.omit": "^2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,12 @@
 
 import { createMiddleware } from './middleware';
 import reactThemerJss from './react-themer-jss';
+import withIsolatedTheme from './react-themer-jss/with-isolated-theme';
 
 // export react-themer-jss singleton as default
 export default reactThemerJss;
 
 export {
   createMiddleware,
+  withIsolatedTheme,
 };

--- a/src/react-themer-jss/with-isolated-theme.js
+++ b/src/react-themer-jss/with-isolated-theme.js
@@ -4,13 +4,17 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
+// @flow
+/* eslint-disable import/prefer-default-export */
+
 import { create as createJss } from 'jss';
-import { create as createInjectSheet } from 'react-jss';
 import preset from 'jss-preset-default';
 import isolate from 'jss-isolate';
+import { create as createInjectSheet } from 'react-jss';
 import { create as createThemer } from 'ca-ui-themer';
 import { create as createReactThemer } from 'ca-ui-react-themer';
-import { createMiddleware as createReactThemerJssMiddleware } from 'ca-ui-react-themer-jss';
+
+import { createMiddleware } from '../middleware';
 
 const jss = createJss(preset());
 jss.use(isolate({
@@ -18,8 +22,8 @@ jss.use(isolate({
 }));
 
 const injectSheet = createInjectSheet(jss);
-const reactThemerJssMiddleware = createReactThemerJssMiddleware(injectSheet);
 const themer = createThemer();
-themer.setMiddleware(reactThemerJssMiddleware);
+themer.setMiddleware(createMiddleware(injectSheet));
+const reactThemerJss = createReactThemer(themer);
 
-export default createReactThemer(themer);
+export default reactThemerJss;


### PR DESCRIPTION
## Status
**READY**

## Description
I'm bumping the depency versions of jss-related plugins for this package. I'm also adding an option to import the module with the [jss-isolate](https://github.com/cssinjs/jss-isolate) plugin added. This can be done by adding the following snippet to the top of your `es6` file:
```
import { withIsolatedTheme } from 'react-themer-jss';
```

This commit will be a major version bump for the package.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* jss-related node_modules
* `src/index.js`
* `src/react-themer-jss/with-isolated-theme.js`
